### PR TITLE
set-up Sunday structure

### DIFF
--- a/_includes/slot-item-small.html
+++ b/_includes/slot-item-small.html
@@ -1,0 +1,19 @@
+{% assign keyline = forloop.index | modulo:3 |  %}
+<div data-category='{{post.category | replace: ' ','-' }}' class="col4 prose pad1 program-block animate contain keyline-right {% if keyline == 1 %} keyline-left{% endif %} keyline-bottom"> 
+  <label>
+    <span class="room">{{post.room}}</span>
+    <span class="light">{{post.capacity}} people</span>
+  </label>
+  <a
+    href='{% if post.category == "lightning" %}/lightning-talks/{% else %}{{site.baseurl}}{{post.url}}{% endif %}'
+    class='sans block space-top2 sessiontitle'>
+   {{post.title}}
+ </a>
+  <label><span class="round space-top2 fill-lighten1 micro strong pad0y">Track {{post.track}}</span></label>
+  <small class='col12 pin-bottomleft pad1'>
+    <span class='inline pad0 dot fill-{{post.category | downcase | replace: ' ','-' }}' title='{{post.theme}}'></span>
+    {{post.name}}{% if post.organization %}, {{post.organization}}{% endif %}
+  </small>
+</div>
+
+

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -20,7 +20,7 @@ color: dark-nav
               {% if page.length %}
                 <small class='inline'>{{page.length}}</small>
               {% else %}
-                <small class='inline pad1x'>{% if page.length %}{{page.length}}{% else %}30min{% endif %}</small>
+                <small class='inline pad1x'>{% if page.length %}{{page.length}}{% elsif page.track %}1hour{% else %}30min{% endif %}</small>
               {% endif %}
             </h3>
 

--- a/_posts/schedule/0200-01-03-example-1.md
+++ b/_posts/schedule/0200-01-03-example-1.md
@@ -1,0 +1,19 @@
+---
+layout: event
+title: Title example 1
+theme: tools
+category: tools
+name: Christian Quest
+organization: OpenStreetMap France
+twitter: openeventdb
+osm:
+capacity: 49
+room: Room QA
+track: 1
+tags:
+  - slot31
+---
+OSM data represent a "static" world and is not designed to share time related data. As an example, we can do route calculations but they cannot take into account traffic jams, closed roads or road work.
+OpenEventDatabase's goal is to provide an open platform to share "events" which are data with "what", "where" and "when" details.
+An open API is available since may 2016, the project is available on https://github.com/openeventdatabase
+The current content is currently (may 2016) fed with weather warning and alerts and motorway traffic informations.

--- a/_posts/schedule/0200-01-03-example-2.md
+++ b/_posts/schedule/0200-01-03-example-2.md
@@ -1,0 +1,19 @@
+---
+layout: event
+title: Title example 2
+theme: tools
+category: tools
+name: Christian Quest
+organization: OpenStreetMap France
+twitter: openeventdb
+osm:
+capacity: 49
+room: Room QC
+track: 2
+tags:
+  - slot31
+---
+OSM data represent a "static" world and is not designed to share time related data. As an example, we can do route calculations but they cannot take into account traffic jams, closed roads or road work.
+OpenEventDatabase's goal is to provide an open platform to share "events" which are data with "what", "where" and "when" details.
+An open API is available since may 2016, the project is available on https://github.com/openeventdatabase
+The current content is currently (may 2016) fed with weather warning and alerts and motorway traffic informations.

--- a/_posts/schedule/0200-01-03-example-3.md
+++ b/_posts/schedule/0200-01-03-example-3.md
@@ -1,0 +1,16 @@
+---
+layout: event
+title: Title example 3
+theme: technical
+category: technical
+name: Frederik Ramm
+organization:
+twitter:
+osm:
+capacity: 49
+room: Nelson Mandela
+track: 3
+tags:
+  - slot31
+---
+This talk explains why so-called "mechanical edits" - edits in which the mapper changes a larger number of objects without looking at them individually, or edits in which the mapper is a computer program - can be detrimental to OpenStreetMap. It outlines the frequent pitfalls waiting for those who attempt mechanical edits, and explains the correct procedures for performing them.

--- a/_posts/schedule/0200-01-03-example-4.md
+++ b/_posts/schedule/0200-01-03-example-4.md
@@ -1,0 +1,16 @@
+---
+layout: event
+title: Title example 4
+theme: technical
+category: technical
+name: Frederik Ramm
+organization:
+twitter:
+osm:
+capacity: 49
+room: Foyer
+track: 4
+tags:
+  - slot31
+---
+This talk explains why so-called "mechanical edits" - edits in which the mapper changes a larger number of objects without looking at them individually, or edits in which the mapper is a computer program - can be detrimental to OpenStreetMap. It outlines the frequent pitfalls waiting for those who attempt mechanical edits, and explains the correct procedures for performing them.

--- a/_posts/schedule/0200-01-03-example-5.md
+++ b/_posts/schedule/0200-01-03-example-5.md
@@ -1,0 +1,16 @@
+---
+layout: event
+title: Title example 5
+theme: technical
+category: technical
+name: Frederik Ramm
+organization:
+twitter:
+osm:
+capacity: 49
+room: Building D
+track: 5
+tags:
+  - slot31
+---
+This talk explains why so-called "mechanical edits" - edits in which the mapper changes a larger number of objects without looking at them individually, or edits in which the mapper is a computer program - can be detrimental to OpenStreetMap. It outlines the frequent pitfalls waiting for those who attempt mechanical edits, and explains the correct procedures for performing them.

--- a/_posts/schedule/0200-01-03-example-6.md
+++ b/_posts/schedule/0200-01-03-example-6.md
@@ -1,0 +1,16 @@
+---
+layout: event
+title: Title example 6
+theme: technical
+category: technical
+name: Frederik Ramm
+organization:
+twitter:
+osm:
+capacity: 49
+room: Building D
+track: 6
+tags:
+  - slot31
+---
+This talk explains why so-called "mechanical edits" - edits in which the mapper changes a larger number of objects without looking at them individually, or edits in which the mapper is a computer program - can be detrimental to OpenStreetMap. It outlines the frequent pitfalls waiting for those who attempt mechanical edits, and explains the correct procedures for performing them.

--- a/program/index.html
+++ b/program/index.html
@@ -496,15 +496,15 @@ themes:
       </div>
       
       
-      <div data-title="Sunday 13:00pm" class="program-block keyline-left keyline-right keyline-bottom fill-lighten0">
+      <div data-title="Sunday 1:00pm" class="program-block keyline-left keyline-right keyline-bottom fill-lighten0">
         <label>
-          <span class="pad1 inline fill-darken0 keyline-right timestamp">13:00pm</span>
+          <span class="pad1 inline fill-darken0 keyline-right timestamp">1:00pm</span>
           <span class="pad1 inline">Lunch</span>
         </label>
       </div>    
       
-      <div data-title="Sunday 14:00pm" class="pad1 fill-darken0 program-block keyline-left keyline-right keyline-bottom">
-        <label>14:00pm</label>
+      <div data-title="Sunday 2:00pm" class="pad1 fill-darken0 program-block keyline-left keyline-right keyline-bottom">
+        <label>2:00pm</label>
       </div>
       <div class="col12 program-blocks clearfix">
         {% for post in site.tags.slot33 reversed | sort:track %}
@@ -512,15 +512,15 @@ themes:
         {% endfor %}
       </div>
       
-      <div data-title="Sunday 15:30pm" class="program-block keyline-left keyline-right keyline-bottom fill-lighten0">
+      <div data-title="Sunday 3:30pm" class="program-block keyline-left keyline-right keyline-bottom fill-lighten0">
         <label>
-          <span class="pad1 inline fill-darken0 keyline-right timestamp">15:30pm</span>
+          <span class="pad1 inline fill-darken0 keyline-right timestamp">3:30pm</span>
           <span class="pad1 inline">Break</span>
         </label>
       </div>
       
-      <div data-title="Sunday 16:00pm" class="pad1 fill-darken0 program-block keyline-left keyline-right keyline-bottom">
-        <label>16:00pm</label>
+      <div data-title="Sunday 4:00pm" class="pad1 fill-darken0 program-block keyline-left keyline-right keyline-bottom">
+        <label>4:00pm</label>
       </div>
       <div class="col12 program-blocks clearfix">
         {% for post in site.tags.slot34 reversed | sort:track %}
@@ -529,16 +529,16 @@ themes:
       </div>
       
       
-      <div data-title="Sunday 17:00pm" class="program-block keyline-left keyline-right keyline-bottom fill-lighten0">
+      <div data-title="Sunday 5:00pm" class="program-block keyline-left keyline-right keyline-bottom fill-lighten0">
         <label>
-          <span class="pad1 inline fill-darken0 keyline-right timestamp">17:00pm</span>
+          <span class="pad1 inline fill-darken0 keyline-right timestamp">5:00pm</span>
           <span class="pad1 inline">Break</span>
         </label>
       </div>
       
-      <div data-title="Sunday 17:30pm" class="program-block keyline-left keyline-right keyline-bottom fill-lighten0">
+      <div data-title="Sunday 5:30pm" class="program-block keyline-left keyline-right keyline-bottom fill-lighten0">
         <label>
-          <span class="pad1 inline fill-darken0 keyline-right timestamp">17:30pm</span>
+          <span class="pad1 inline fill-darken0 keyline-right timestamp">5:30pm</span>
           <span class="pad1 inline">End</span>
         </label>
       </div>

--- a/program/index.html
+++ b/program/index.html
@@ -462,243 +462,86 @@ themes:
 
       <!-- SUNDAY -->
       <h2>Sunday</h2>
-      <div class="">
-        <p>The Sunday program will be added shortly. It will focus on workshops and sharing knowledge. Together we'll discover the next great thing in mapping and hacking but please be kind to our network (bandwidth currently unconfirmed).</p>
+  
+      <div data-title="Sunday 9:00am" class="program-block keyline-all fill-lighten0">
+        <label>
+          <span class="pad1 inline fill-darken0 keyline-right timestamp">9:00am</span>
+          <span class="pad1 inline">Coffee / Tea</span>
+        </label>
       </div>
-      <!--
-      <div data-title="Sunday 8:00am" class="program-block keyline-all fill-lighten0">
-          <label>
-            <span class="pad1 inline fill-darken0 keyline-right timestamp">8:00am</span>
-            <span class="pad1 inline">Coffee / Tea</span>
-          </label>
-        </div>
-        <div data-title="Sunday 9:00am" class="pad1 fill-darken0 program-block keyline-left keyline-right keyline-bottom">
-          <label>9:00am</label>
-        </div>
-        <div class="col12 program-blocks keyline-bottom clearfix">
-
-            <div data-category="workshop" class="col4 prose pad1 program-block animate contain keyline-left keyline-right">
-              <label>
-                <span class="room">Pigott 101</span>
-                <span class="light"> 49 people</span>
-              </label>
-              <div class="sans block space-top2 sessiontitle space-bottom1">
-               Make maps more ​interactive​ with the magic of a geocoding search box
-              </div>
-              <label><span class="round space-top2 fill-lighten1 micro strong pad1x pad0y">Geocoding</span></label>
-              <small class="col12 pin-bottomleft pad1 space-top2">
-                <span class="inline pad0 dot fill-workshops" title="workshops"></span>
-                Rhonda Glennon, Diana Shkolnikov
-              </small>
-            </div>
-
-
-            <div data-category="workshop" class="col4 prose pad1 program-block animate contain keyline-right">
-              <label>
-                <span class="room">Pigott 102</span>
-                <span class="light"> 49 people</span>
-              </label>
-              <div class="sans block space-top2 sessiontitle space-bottom1">
-                Make an interactive map with OSM data!
-              </div>
-              <label><span class="round space-top2 fill-lighten1 micro strong pad1x pad0y">Make maps</span></label>
-              <small class="col12 pin-bottomleft pad1">
-                <span class="inline pad0 dot fill-workshops space-top2" title="workshops"></span>
-                Lyzi Diamond, Dan Swick
-              </small>
-            </div>
-
-
-            <div data-category="workshop" class="col4 prose pad1 program-block animate contain keyline-left keyline-right">
-              <label>
-                <span class="room">Pigott 108</span>
-                <span class="light"> 30 people</span>
-              </label>
-              <div class="sans block space-top2 sessiontitle space-bottom1">
-               How to make the most out of OSM Evangelization
-              </div>
-              <label><span class="round space-top2 fill-lighten1 micro strong pad1x pad0y">Community building</span></label>
-              <small class="col12 pin-bottomleft pad1">
-                <span class="inline pad0 dot fill-workshops space-top2" title="workshops"></span>
-                Javier Carranza
-              </small>
-            </div>
-        </div>
-
-        <div data-title="Sunday 10:30am" class="pad1 fill-darken0 program-block keyline-left keyline-right keyline-bottom">
-          <label>10:30am</label>
-        </div>
-        <div class="col12 program-blocks keyline-bottom clearfix">
-
-            <div data-category="workshop" class="col4 prose pad1 program-block animate contain keyline-left keyline-right">
-              <label>
-                <span class="room">Pigott 101</span>
-                <span class="light"> 49 people</span>
-              </label>
-              <div class="sans block space-top2 sessiontitle space-bottom1">
-                Interpreting Satellite Imagery for OpenStreetMap
-              </div>
-              <label><span class="round space-top2 fill-lighten1 micro strong pad1x pad0y">Geocoding</span></label>
-              <small class="col12 pin-bottomleft pad1">
-                <span class="inline pad0 dot fill-workshops space-top2" title="workshops"></span>
-               James Sondag and Christopher Orndorff
-              </small>
-            </div>
-
-
-            <div data-category="workshop" class="col4 prose pad1 program-block animate contain keyline-right">
-              <label>
-                <span class="room">Pigott 102</span>
-                <span class="light"> 49 people</span>
-              </label>
-              <div class="sans block space-top2 sessiontitle space-bottom1">
-               Rendering your own maps
-              </div>
-              <label><span class="round space-top2 fill-lighten1 micro strong pad1x pad0y">Make maps</span></label>
-              <small class="col12 pin-bottomleft pad1">
-                <span class="inline pad0 dot fill-workshops space-top2" title="workshops"></span>
-                Paul Norman
-              </small>
-            </div>
-
-
-            <div data-category="workshop" class="col4 prose pad1 program-block animate contain keyline-right">
-              <label>
-                <span class="room">Pigott 108</span>
-                <span class="light"> 30 people</span>
-              </label>
-              <div class="sans block space-top2 sessiontitle space-bottom1">
-               Making mapping fun and engaging future mappers
-              </div>
-              <label><span class="round space-top2 fill-lighten1 micro strong pad1x pad0y">Community building</span></label>
-              <small class="col12 pin-bottomleft pad1">
-                <span class="inline pad0 dot fill-workshops space-top2" title="workshops"></span>
-                Miriam Gonzalez
-              </small>
-            </div>
-        </div>
-
-
-      <div data-title="Sunday 12:00pm" class="program-block keyline-left keyline-right keyline-bottom fill-lighten0">
-          <label>
-            <span class="pad1 inline fill-darken0 keyline-right timestamp">12:00pm</span>
-            <span class="pad1 inline">Lunch</span>
-          </label>
-        </div>
-
-
-        <div data-title="Sunday 13:00pm" class="pad1 fill-darken0 program-block keyline-left keyline-right keyline-bottom">
-          <label>13:00pm</label>
-        </div>
-        <div class="col12 program-blocks keyline-bottom clearfix">
-
-            <div data-category="workshop" class="col4 prose pad1 program-block animate contain keyline-left keyline-right workshop">
-              <label>
-                <span class="room">Pigott 101</span>
-                <span class="light"> 49 people</span>
-              </label>
-              <div class="sans block space-top2 sessiontitle space-bottom1">
-                 Let's add bike-share stations to OSM
-              </div>
-              <label><span class="round space-top2 fill-lighten1 micro strong pad1x pad0y">tagging and mapping</span></label>
-              <small class="col12 pin-bottomleft pad1">
-                <span class="inline pad0 dot fill-workshops space-top2" title="workshops"></span>
-               Jim Walseth
-              </small>
-            </div>
-
-
-            <div data-category="workshop" class="col4 prose pad1 program-block animate contain workshop">
-              <label>
-                <span class="room">Pigott 102</span>
-                <span class="light"> 49 people</span>
-              </label>
-              <div class="sans block space-top2 sessiontitle space-bottom1">
-                Faites vos jeux - Here's the New MapRoulette
-              </div>
-              <label><span class="round space-top2 fill-lighten1 micro strong pad1x pad0y">contribute to tools</span></label>
-              <small class="col12 pin-bottomleft pad1">
-                <span class="inline pad0 dot fill-workshops space-top2" title="workshops"></span>
-                 Martijn van Exel
-              </small>
-            </div>
-
-
-            <div data-category="workshop" class="col4 prose pad1 program-block animate contain keyline-left keyline-right workshop">
-              <label>
-                <span class="room">Pigott 108</span>
-                <span class="light"> 30 people</span>
-              </label>
-              <div class="sans block space-top2 sessiontitle space-bottom1">
-               OpenDroneMap <3 OpenAerialMap <3 OpenStreetMap
-              </div>
-              <label><span class="round space-top2 fill-lighten1 micro strong pad1x pad0y">flying</span></label>
-              <small class="col12 pin-bottomleft pad1">
-                <span class="inline pad0 dot fill-workshops space-top2" title="workshops"></span>
-                Stephen Mather, Cristiano Giovando, Nate Smith
-              </small>
-            </div>
-        </div>
-
-        <div data-title="Sunday 14:30pm" class="pad1 fill-darken0 program-block keyline-left keyline-right keyline-bottom">
-          <label>14:30pm</label>
-        </div>
-        <div class="col12 program-blocks keyline-bottom clearfix">
-
-            <div data-category="workshop" class="col4 prose pad1 program-block animate contain keyline-left keyline-right workshop">
-              <label>
-                <span class="room">Pigott 101</span>
-                <span class="light"> 49 people</span>
-              </label>
-              <div class="sans block space-top2 sessiontitle space-bottom1">
-                Tagging and mapping for routing and navigation
-              </div>
-              <label><span class="round space-top2 fill-lighten1 micro strong pad1x pad0y">tagging and mapping</span></label>
-              <small class="col12 pin-bottomleft pad1">
-                <span class="inline pad0 dot fill-workshops space-top2" title="workshops"></span>
-                Sivaram Ramachandran
-              </small>
-            </div>
-
-
-            <div data-category="workshop" class="col4 prose pad1 program-block animate contain workshop">
-              <label>
-                <span class="room">Pigott 102</span>
-                <span class="light"> 49 people</span>
-              </label>
-              <div class="sans block space-top2 sessiontitle space-bottom1">
-                Customizing iD for Developers
-              </div>
-              <label><span class="round space-top2 fill-lighten1 micro strong pad1x pad0y">contribute to tools</span></label>
-              <small class="col12 pin-bottomleft pad1">
-                <span class="inline pad0 dot fill-workshops space-top2" title="workshops"></span>
-                Bryan Housel
-              </small>
-            </div>
-
-
-            <div data-category="workshop" class="col4 prose pad1 program-block animate contain keyline-left keyline-right workshop">
-              <label>
-                <span class="room">Pigott 108</span>
-                <span class="light"> 30 people</span>
-              </label>
-              <div class="sans block space-top2 sessiontitle space-bottom1">
-               OpenDroneMap <3 OpenAerialMap <3 OpenStreetMap
-              </div>
-              <label><span class="round space-top2 fill-lighten1 micro strong pad1x pad0y">flying</span></label>
-              <small class="col12 pin-bottomleft pad1">
-                <span class="inline pad0 dot fill-workshops space-top2" title="workshops"></span>
-                Stephen Mather, Cristiano Giovando, Nate Smith
-              </small>
-            </div>
-        </div>
-
-      <div data-title="Sunday 16:00pm" class="program-block keyline-left keyline-right keyline-bottom fill-lighten0">
-          <label>
-            <span class="pad1 inline fill-darken0 keyline-right timestamp">16:00pm</span>
-            <span class="pad1 inline">End</span>
-          </label>
-        </div>
+      
+      <div data-title="Sunday 10:00am" class="pad1 fill-darken0 program-block keyline-left keyline-right keyline-bottom">
+        <label>10:00am</label>
+      </div>
+      <div class="col12 program-blocks clearfix">
+        {% for post in site.tags.slot31 reversed | sort:track %}
+        {% include slot-item-small.html %}
+        {% endfor %}
+      </div>
+      
+      <div data-title="Sunday 11:00am" class="program-block keyline-all fill-lighten0">
+        <label>
+          <span class="pad1 inline fill-darken0 keyline-right timestamp">11:00am</span>
+          <span class="pad1 inline">Break</span>
+        </label>
+      </div>
+      
+      <div data-title="Sunday 11:30am" class="pad1 fill-darken0 program-block keyline-left keyline-right keyline-bottom">
+        <label>11:30am</label>
+      </div>
+      <div class="col12 program-blocks clearfix">
+        {% for post in site.tags.slot32 reversed | sort:track %}
+        {% include slot-item-small.html %}
+        {% endfor %}
+      </div>
+      
+      
+      <div data-title="Sunday 13:00pm" class="program-block keyline-left keyline-right keyline-bottom fill-lighten0">
+        <label>
+          <span class="pad1 inline fill-darken0 keyline-right timestamp">13:00pm</span>
+          <span class="pad1 inline">Lunch</span>
+        </label>
+      </div>    
+      
+      <div data-title="Sunday 14:00pm" class="pad1 fill-darken0 program-block keyline-left keyline-right keyline-bottom">
+        <label>14:00pm</label>
+      </div>
+      <div class="col12 program-blocks clearfix">
+        {% for post in site.tags.slot33 reversed | sort:track %}
+        {% include slot-item-small.html %}
+        {% endfor %}
+      </div>
+      
+      <div data-title="Sunday 15:30pm" class="program-block keyline-left keyline-right keyline-bottom fill-lighten0">
+        <label>
+          <span class="pad1 inline fill-darken0 keyline-right timestamp">15:30pm</span>
+          <span class="pad1 inline">Break</span>
+        </label>
+      </div>
+      
+      <div data-title="Sunday 16:00pm" class="pad1 fill-darken0 program-block keyline-left keyline-right keyline-bottom">
+        <label>16:00pm</label>
+      </div>
+      <div class="col12 program-blocks clearfix">
+        {% for post in site.tags.slot34 reversed | sort:track %}
+        {% include slot-item-small.html %}
+        {% endfor %}
+      </div>
+      
+      
+      <div data-title="Sunday 17:00pm" class="program-block keyline-left keyline-right keyline-bottom fill-lighten0">
+        <label>
+          <span class="pad1 inline fill-darken0 keyline-right timestamp">17:00pm</span>
+          <span class="pad1 inline">Break</span>
+        </label>
+      </div>
+      
+      <div data-title="Sunday 17:30pm" class="program-block keyline-left keyline-right keyline-bottom fill-lighten0">
+        <label>
+          <span class="pad1 inline fill-darken0 keyline-right timestamp">17:30pm</span>
+          <span class="pad1 inline">End</span>
+        </label>
+      </div>
 
 
 
@@ -714,7 +557,7 @@ themes:
         </div>
         </div>
       </div>
-    -->
+
 
 
     </div>


### PR DESCRIPTION
per #34, I started to build the structure for Sunday.

Posts for Sunday have two new variables:
- capacity
- track

The `track` number keeps the 6 talks in each slot in order.

For tags, the first slot on Sunday is `slot31`. The next is `slot32` and then `slot33` and finally `slot33`.

I added 6 example posts for testing - that we should remove before we merge!

![image](https://cloud.githubusercontent.com/assets/2180540/16884664/75317f96-4a7f-11e6-8481-16c377103b21.png)

@tatsvc would love your eyes on this PR and make/recommend any necessary changes

cc @RobJN
