### PR TITLE
drop newsletter and demote map

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,5 @@ layout: default
 {% include header.html %}
 {% include about.html %}
 {% include livestream.html %}
-{% include newsletter.html %}
-{% include map.html %}
 {% include sponsors.html %}
+{% include map.html %}


### PR DESCRIPTION
Post event changes. We really should get the sponsors icons more prominent at this stage somehow, so demoting the map below that and removing the newsletter sign up thing (time to put that on the 2017 site!)
